### PR TITLE
[feat] procut 에서 상세 페이지 이동 할 때 seq 에 맞는 상품 나오게 하기

### DIFF
--- a/fifteen/src/App.jsx
+++ b/fifteen/src/App.jsx
@@ -12,6 +12,7 @@ import MyPage from './pages/mypage/MyPage';
 import Profile from './pages/profile/ProfilePage';
 import Wishlist from "./pages/wishlist/WishlistPage";
 import Coupon from './pages/coupon/CouponPage';
+import ProductPage from "./pages/product/product_page";
 
 class App extends Component{
     render() {
@@ -25,6 +26,7 @@ class App extends Component{
                 <Route path='/profile' component={Profile}/>
                 <Route path='/wishlist' component={Wishlist}/>
                 <Route path='/coupon' component={Coupon}/>
+                <Route path='/product/:productSeq' component={ProductPage}/>
             </div>
         );
     }

--- a/fifteen/src/components/bestSeller/Bestseller.jsx
+++ b/fifteen/src/components/bestSeller/Bestseller.jsx
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import './bestseller.css';
 import axios from 'axios';
 import _ from 'lodash';
-import {withRouter} from "react-router-dom";
+import {Link, withRouter} from "react-router-dom";
 
 
 class Bestseller extends Component {
@@ -42,16 +42,18 @@ class Bestseller extends Component {
                     <div className="bestSellerTitle">Best Seller</div>
                     <div className="bestSellerBooks">
                         {this.state.products.map(arr => (
-                            <div key={arr.productSeq}>
-                                <div className="bestSellerBookItem">
-                                    <div className="bestSellerBookItemImg">
-                                        {arr.image}
+                            <Link to={`/product/${arr.productSeq}`}>
+                                <div key={arr.productSeq}>
+                                    <div className="bestSellerBookItem">
+                                        <div className="bestSellerBookItemImg">
+                                            {arr.image}
+                                        </div>
+                                        <div className="bestSellerBookItemTitle">{arr.title}</div>
+                                        <div className="bestSellerBookItemSub">지은이 : {arr.author} | 출판사 : {arr.publisher}</div>
+                                        <div className="bestSellerBookItemPrice">{arr.price}</div>
                                     </div>
-                                    <div className="bestSellerBookItemTitle">{arr.title}</div>
-                                    <div className="bestSellerBookItemSub">지은이 : {arr.author} | 출판사 : {arr.publisher}</div>
-                                    <div className="bestSellerBookItemPrice">{arr.price}</div>
                                 </div>
-                            </div>
+                            </Link>
                         ))}
                     </div>
                 </div>

--- a/fifteen/src/components/product/product.jsx
+++ b/fifteen/src/components/product/product.jsx
@@ -3,44 +3,50 @@ import './product.css';
 import axios from "axios";
 import Review from "../review/review";
 import QnA from "../Q&A/Q&A";
+import _ from "lodash";
 
 class Product extends Component{
 
         constructor(props) {
             super(props);
             this.state = {
-                productInfoArr: [{'productSeq': '1'}]
+                productSeq : '0',
+                products : [{'' : ''}],
             }
         }
-        getProductInfoList = async function () {
-            let result =await axios ({
-                method : 'GET',
-                url : 'http://52.79.196.94:8080/product/select_all',
-                data: { },
-                headers : {
-                    'Access-Control-Allow-Origin' : '*',
-                    "Content-Type" : 'application/json'
-                },
-            });
-            this.setState({productInfoArr : result.data});
-        };
 
-        componentDidMount() {
-            this.getProductInfoList();
-        }
+    getBookList = async function() {
+        let result =await axios ({
+            method : 'GET',
+            url : 'http://52.79.196.94:8080/product/select_all',
+            data: { },
+            headers : {
+                'Access-Control-Allow-Origin' : '*',
+                "Content-Type" : 'application/json'
+            },
+        })
+        this.setState({products : result.data});
+        // this.setState({productSeq : this.props.productSeq});
+    }
+
+    componentDidMount() {
+        this.getBookList();
+        console.log(this.props);
+    }
+
     render(){
         return(
             <div className="product">
                 <div className="product-main">
                     <div className="product-main-imgBox">
-                        <img className="product-main-imgBox-img" src={this.state.productInfoArr[0].image}/></div>
+                        <img className="product-main-imgBox-img" src={this.state.products[this.state.productSeq].img}/></div>
                     <div className="product-main-box">
-                        <div className="product-main-box-category">{this.state.productInfoArr[0].field}</div>
-                        <div className="product-main-box-title">{this.state.productInfoArr[0].title}</div>
-                        <div className="product-main-box-author">지은이 : {this.state.productInfoArr[0].author} / 출판사 : {this.state.productInfoArr[0].publisher}</div>
-                        <div className="product-main-box-comment">{this.state.productInfoArr[0].a_intro}</div>
+                        <div className="product-main-box-category">{this.state.products[this.state.productSeq].field}</div>
+                        <div className="product-main-box-title">{this.state.products[this.state.productSeq].title}</div>
+                        <div className="product-main-box-author">지은이 : {this.state.products[this.state.productSeq].author} / 출판사 : {this.state.products[this.state.productSeq].publisher}</div>
+                        <div className="product-main-box-comment">{this.state.products[this.state.productSeq].a_intro}</div>
                         <div className="product-main-box-price-total">Total</div>
-                        <div className="product-main-box-price">{this.state.productInfoArr[0].price}원</div>
+                        <div className="product-main-box-price">{this.state.products[this.state.productSeq].price}원</div>
                         <div className="product-main-box-button">
                             <button className="product-main-box-button-buy">BUY NOW</button>
                             <button className="product-main-box-button-cart">ADD TO CART</button>
@@ -58,11 +64,11 @@ class Product extends Component{
                         <div className="product-detail-box-information">
                             <div className="product-detail-box-information-box">
                                 <div className="product-detail-box-information-title">저자 소개</div>
-                                {this.state.productInfoArr[0].a_intro}
+                                {this.state.products[this.state.productSeq].a_intro}
                             </div>
                             <div className="product-detail-box-information-box">
                                 <div className="product-detail-box-information-title">작품 소개</div>
-                                {this.state.productInfoArr[0].content}
+                                {this.state.products[this.state.productSeq].content}
                             </div>
                             <div className="product-detail-box-information-box">
                                 <div className="product-detail-box-information-title">배송 방법</div>


### PR DESCRIPTION
react-router를 이용해서 props로 productSeq 를 넘겼는데 주소에선 반영이 되는데 상세 페이지 컴포넌트에서 props.match 가 undefind 라서 확인 할 수가 없다.. 왜일까..?